### PR TITLE
Search for tasks based on tags

### DIFF
--- a/src/main/java/seedu/taskify/logic/commands/TagSearchCommand.java
+++ b/src/main/java/seedu/taskify/logic/commands/TagSearchCommand.java
@@ -17,8 +17,8 @@ public class TagSearchCommand extends Command {
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Searches for tasks based on the tags "
                                                        + "specified (case-insensitive) and displays them as a list "
                                                        + "with index numbers.\n"
-                                                       + "Parameters: TAGS [MORE_TAGS]...\n"
-                                                       + "Example: " + COMMAND_WORD + " alice bob charlie";
+                                                       + "Parameters: TAG [MORE_TAGS]...\n"
+                                                       + "Example: " + COMMAND_WORD + "lab tutorial";
 
     private final TagContainsKeywordsPredicate predicate;
 

--- a/src/main/java/seedu/taskify/logic/commands/TagSearchCommand.java
+++ b/src/main/java/seedu/taskify/logic/commands/TagSearchCommand.java
@@ -1,0 +1,43 @@
+package seedu.taskify.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+
+import seedu.taskify.commons.core.Messages;
+import seedu.taskify.model.Model;
+import seedu.taskify.model.task.TagContainsKeywordsPredicate;
+
+/**
+ * TagSearchs and lists all tasks in address book whose tag contains any of the argument keywords.
+ * Keyword matching is case insensitive.
+ */
+public class TagSearchCommand extends Command {
+
+    public static final String COMMAND_WORD = "tag-search";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Searches for tasks based on the tags "
+                                                       + "specified (case-insensitive) and displays them as a list "
+                                                       + "with index numbers.\n"
+                                                       + "Parameters: TAGS [MORE_TAGS]...\n"
+                                                       + "Example: " + COMMAND_WORD + " alice bob charlie";
+
+    private final TagContainsKeywordsPredicate predicate;
+
+    public TagSearchCommand(TagContainsKeywordsPredicate predicate) {
+        this.predicate = predicate;
+    }
+
+    @Override
+    public CommandResult execute(Model model) {
+        requireNonNull(model);
+        model.updateFilteredTaskList(predicate);
+        return new CommandResult(
+                String.format(Messages.MESSAGE_TASKS_LISTED_OVERVIEW, model.getFilteredTaskList().size()));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                       || (other instanceof TagSearchCommand // instanceof handles nulls
+                                   && predicate.equals(((TagSearchCommand) other).predicate)); // state check
+    }
+}

--- a/src/main/java/seedu/taskify/logic/parser/TagSearchCommandParser.java
+++ b/src/main/java/seedu/taskify/logic/parser/TagSearchCommandParser.java
@@ -1,0 +1,34 @@
+package seedu.taskify.logic.parser;
+
+import static seedu.taskify.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+
+import java.util.Arrays;
+
+import seedu.taskify.logic.commands.TagSearchCommand;
+import seedu.taskify.logic.parser.exceptions.ParseException;
+import seedu.taskify.model.task.TagContainsKeywordsPredicate;
+
+/**
+ * Parses input arguments and creates a new TagSearchCommand object
+ */
+public class TagSearchCommandParser implements Parser<TagSearchCommand> {
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the TagSearchCommand
+     * and returns a TagSearchCommand object for execution.
+     *
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public TagSearchCommand parse(String args) throws ParseException {
+        String trimmedArgs = args.trim();
+        if (trimmedArgs.isEmpty()) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, TagSearchCommand.MESSAGE_USAGE));
+        }
+
+        String[] tagKeywords = trimmedArgs.split("\\s+");
+
+        return new TagSearchCommand(new TagContainsKeywordsPredicate(Arrays.asList(tagKeywords)));
+    }
+
+}

--- a/src/main/java/seedu/taskify/logic/parser/TaskifyParser.java
+++ b/src/main/java/seedu/taskify/logic/parser/TaskifyParser.java
@@ -15,6 +15,7 @@ import seedu.taskify.logic.commands.ExitCommand;
 import seedu.taskify.logic.commands.FindCommand;
 import seedu.taskify.logic.commands.HelpCommand;
 import seedu.taskify.logic.commands.ListCommand;
+import seedu.taskify.logic.commands.TagSearchCommand;
 import seedu.taskify.logic.parser.exceptions.ParseException;
 
 /**
@@ -61,6 +62,9 @@ public class TaskifyParser {
 
         case ListCommand.COMMAND_WORD:
             return new ListCommand();
+
+        case TagSearchCommand.COMMAND_WORD:
+            return new TagSearchCommandParser().parse(arguments);
 
         case ExitCommand.COMMAND_WORD:
             return new ExitCommand();

--- a/src/main/java/seedu/taskify/model/UserPrefs.java
+++ b/src/main/java/seedu/taskify/model/UserPrefs.java
@@ -14,7 +14,7 @@ import seedu.taskify.commons.core.GuiSettings;
 public class UserPrefs implements ReadOnlyUserPrefs {
 
     private GuiSettings guiSettings = new GuiSettings();
-    private Path taskifyFilePath = Paths.get("data" , "addressbook.json");
+    private Path taskifyFilePath = Paths.get("data" , "taskify.json");
 
     /**
      * Creates a {@code UserPrefs} with default values.

--- a/src/main/java/seedu/taskify/model/task/TagContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/taskify/model/task/TagContainsKeywordsPredicate.java
@@ -1,0 +1,43 @@
+package seedu.taskify.model.task;
+
+import java.util.List;
+import java.util.Set;
+import java.util.function.Predicate;
+
+import seedu.taskify.commons.util.StringUtil;
+import seedu.taskify.model.tag.Tag;
+
+
+/**
+ * Tests that a {@code Task}'s {@code Tag} matches any of the keywords given.
+ */
+public class TagContainsKeywordsPredicate implements Predicate<Task> {
+    private final List<String> keywords;
+
+    public TagContainsKeywordsPredicate(List<String> keywords) {
+        this.keywords = keywords;
+    }
+
+    @Override
+    public boolean test(Task task) {
+
+        Set<Tag> tags = task.getTags();
+        String tagsString = tags.stream()
+                                .map(tag -> tag.toString() + " ")
+                                .map(tag -> tag.replaceAll("[\\[\\]]*", ""))
+                                .reduce("", String::concat);
+        System.out.println(tagsString);
+
+        return keywords.stream()
+                       .anyMatch(keyword -> StringUtil.containsWordIgnoreCase(tagsString,
+                               keyword));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                       || (other instanceof TagContainsKeywordsPredicate // instanceof handles nulls
+                                   && keywords.equals(((TagContainsKeywordsPredicate) other).keywords)); // state check
+    }
+
+}

--- a/src/test/java/seedu/taskify/logic/commands/TagSearchCommandTest.java
+++ b/src/test/java/seedu/taskify/logic/commands/TagSearchCommandTest.java
@@ -1,0 +1,83 @@
+package seedu.taskify.logic.commands;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.taskify.commons.core.Messages.MESSAGE_TASKS_LISTED_OVERVIEW;
+import static seedu.taskify.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.taskify.testutil.TypicalTasks.ALICE;
+import static seedu.taskify.testutil.TypicalTasks.BENSON;
+import static seedu.taskify.testutil.TypicalTasks.DANIEL;
+import static seedu.taskify.testutil.TypicalTasks.getTypicalAddressBook;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.taskify.model.Model;
+import seedu.taskify.model.ModelManager;
+import seedu.taskify.model.UserPrefs;
+import seedu.taskify.model.task.TagContainsKeywordsPredicate;
+
+/**
+ * Contains integration tests (interaction with the Model) for {@code TagSearchCommand}.
+ */
+public class TagSearchCommandTest {
+    private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+    private Model expectedModel = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+
+    @Test
+    public void equals() {
+        TagContainsKeywordsPredicate firstPredicate =
+                new TagContainsKeywordsPredicate(Collections.singletonList("first"));
+        TagContainsKeywordsPredicate secondPredicate =
+                new TagContainsKeywordsPredicate(Collections.singletonList("second"));
+
+        TagSearchCommand tagSearchFirstCommand = new TagSearchCommand(firstPredicate);
+        TagSearchCommand tagSearchSecondCommand = new TagSearchCommand(secondPredicate);
+
+        // same object -> returns true
+        assertTrue(tagSearchFirstCommand.equals(tagSearchFirstCommand));
+
+        // same values -> returns true
+        TagSearchCommand tagSearchFirstCommandCopy = new TagSearchCommand(firstPredicate);
+        assertTrue(tagSearchFirstCommand.equals(tagSearchFirstCommandCopy));
+
+        // different types -> returns false
+        assertFalse(tagSearchFirstCommand.equals(1));
+
+        // null -> returns false
+        assertFalse(tagSearchFirstCommand.equals(null));
+
+        // different task -> returns false
+        assertFalse(tagSearchFirstCommand.equals(tagSearchSecondCommand));
+    }
+
+    @Test
+    public void execute_zeroKeywords_noTaskFound() {
+        String expectedMessage = String.format(MESSAGE_TASKS_LISTED_OVERVIEW, 0);
+        TagContainsKeywordsPredicate predicate = preparePredicate(" ");
+        TagSearchCommand command = new TagSearchCommand(predicate);
+        expectedModel.updateFilteredTaskList(predicate);
+        assertCommandSuccess(command, model, expectedMessage, expectedModel);
+        assertEquals(Collections.emptyList(), model.getFilteredTaskList());
+    }
+
+    @Test
+    public void execute_multipleKeywords_multipleTasksFound() {
+        String expectedMessage = String.format(MESSAGE_TASKS_LISTED_OVERVIEW, 3);
+        TagContainsKeywordsPredicate predicate = preparePredicate("friends owesMoney");
+        TagSearchCommand command = new TagSearchCommand(predicate);
+        expectedModel.updateFilteredTaskList(predicate);
+        assertCommandSuccess(command, model, expectedMessage, expectedModel);
+        assertEquals(Arrays.asList(ALICE, BENSON, DANIEL), model.getFilteredTaskList());
+    }
+
+    /**
+     * Parses {@code userInput} into a {@code TagContainsKeywordsPredicate}.
+     */
+    private TagContainsKeywordsPredicate preparePredicate(String userInput) {
+        return new TagContainsKeywordsPredicate(Arrays.asList(userInput.split("\\s+")));
+    }
+}

--- a/src/test/java/seedu/taskify/logic/commands/TagSearchCommandTest.java
+++ b/src/test/java/seedu/taskify/logic/commands/TagSearchCommandTest.java
@@ -50,7 +50,7 @@ public class TagSearchCommandTest {
         // null -> returns false
         assertFalse(tagSearchFirstCommand.equals(null));
 
-        // different task -> returns false
+        // different commands -> returns false
         assertFalse(tagSearchFirstCommand.equals(tagSearchSecondCommand));
     }
 

--- a/src/test/java/seedu/taskify/logic/parser/TagSearchCommandParserTest.java
+++ b/src/test/java/seedu/taskify/logic/parser/TagSearchCommandParserTest.java
@@ -1,0 +1,35 @@
+package seedu.taskify.logic.parser;
+
+import static seedu.taskify.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.taskify.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.taskify.logic.parser.CommandParserTestUtil.assertParseSuccess;
+
+import java.util.Arrays;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.taskify.logic.commands.TagSearchCommand;
+import seedu.taskify.model.task.TagContainsKeywordsPredicate;
+
+public class TagSearchCommandParserTest {
+
+    private TagSearchCommandParser parser = new TagSearchCommandParser();
+
+    @Test
+    public void parse_emptyArg_throwsParseException() {
+        assertParseFailure(parser, "     ", String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                           TagSearchCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_validArgs_returnsTagSearchCommand() {
+        // no leading and trailing whitespaces
+        TagSearchCommand expectedTagSearchCommand =
+                new TagSearchCommand(new TagContainsKeywordsPredicate(Arrays.asList("Module", "Tutorial")));
+        assertParseSuccess(parser, "Module Tutorial", expectedTagSearchCommand);
+
+        // multiple whitespaces between keywords
+        assertParseSuccess(parser, " \n Module \n \t Tutorial  \t", expectedTagSearchCommand);
+    }
+
+}

--- a/src/test/java/seedu/taskify/model/task/TagContainsKeywordsPredicateTest.java
+++ b/src/test/java/seedu/taskify/model/task/TagContainsKeywordsPredicateTest.java
@@ -1,0 +1,75 @@
+package seedu.taskify.model.task;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.taskify.testutil.TaskBuilder;
+
+public class TagContainsKeywordsPredicateTest {
+
+    @Test
+    public void equals() {
+        List<String> firstPredicateKeywordList = Collections.singletonList("first");
+        List<String> secondPredicateKeywordList = Arrays.asList("first", "second");
+
+        TagContainsKeywordsPredicate firstPredicate = new TagContainsKeywordsPredicate(firstPredicateKeywordList);
+        TagContainsKeywordsPredicate secondPredicate = new TagContainsKeywordsPredicate(secondPredicateKeywordList);
+
+        // same object -> returns true
+        assertTrue(firstPredicate.equals(firstPredicate));
+
+        // same values -> returns true
+        TagContainsKeywordsPredicate firstPredicateCopy = new TagContainsKeywordsPredicate(firstPredicateKeywordList);
+        assertTrue(firstPredicate.equals(firstPredicateCopy));
+
+        // different types -> returns false
+        assertFalse(firstPredicate.equals(1));
+
+        // null -> returns false
+        assertFalse(firstPredicate.equals(null));
+
+        // different task -> returns false
+        assertFalse(firstPredicate.equals(secondPredicate));
+    }
+
+    @Test
+    public void test_tagContainsKeywords_returnsTrue() {
+        // One keyword
+        TagContainsKeywordsPredicate predicate = new TagContainsKeywordsPredicate(Collections.singletonList("Module"));
+        assertTrue(predicate.test(new TaskBuilder().withTags("Module", "Tutorial").build()));
+
+        // Multiple keywords
+        predicate = new TagContainsKeywordsPredicate(Arrays.asList("Module", "Tutorial"));
+        assertTrue(predicate.test(new TaskBuilder().withTags("Module", "Tutorial").build()));
+
+        // Only one matching keyword
+        predicate = new TagContainsKeywordsPredicate(Arrays.asList("Lab", "Tutorial"));
+        assertTrue(predicate.test(new TaskBuilder().withTags("Module", "Tutorial").build()));
+
+        // Mixed-case keywords
+        predicate = new TagContainsKeywordsPredicate(Arrays.asList("MoDuLe", "tuTorIAL"));
+        assertTrue(predicate.test(new TaskBuilder().withTags("Module", "Tutorial").build()));
+    }
+
+    @Test
+    public void test_tagDoesNotContainKeywords_returnsFalse() {
+        // Zero keywords
+        TagContainsKeywordsPredicate predicate = new TagContainsKeywordsPredicate(Collections.emptyList());
+        assertFalse(predicate.test(new TaskBuilder().withTags("Module").build()));
+
+        // Non-matching keyword
+        predicate = new TagContainsKeywordsPredicate(Arrays.asList("Assignment"));
+        assertFalse(predicate.test(new TaskBuilder().withTags("Module", "Tutorial").build()));
+
+        // Keywords match description and address, but does not match tag
+        predicate = new TagContainsKeywordsPredicate(Arrays.asList("12345", "Main", "Street"));
+        assertFalse(predicate.test(new TaskBuilder().withTags("Lab").withDescription("12345")
+                                           .withStatus(StatusType.NOT_DONE).withAddress("Main Street").build()));
+    }
+}

--- a/src/test/java/seedu/taskify/model/task/TagContainsKeywordsPredicateTest.java
+++ b/src/test/java/seedu/taskify/model/task/TagContainsKeywordsPredicateTest.java
@@ -34,7 +34,7 @@ public class TagContainsKeywordsPredicateTest {
         // null -> returns false
         assertFalse(firstPredicate.equals(null));
 
-        // different task -> returns false
+        // different predicates -> returns false
         assertFalse(firstPredicate.equals(secondPredicate));
     }
 
@@ -66,6 +66,10 @@ public class TagContainsKeywordsPredicateTest {
         // Non-matching keyword
         predicate = new TagContainsKeywordsPredicate(Arrays.asList("Assignment"));
         assertFalse(predicate.test(new TaskBuilder().withTags("Module", "Tutorial").build()));
+
+        // Non-matching keyword
+        predicate = new TagContainsKeywordsPredicate(Arrays.asList("Module", "Tutorial"));
+        assertFalse(predicate.test(new TaskBuilder().withTags("ModuleTutorial").build()));
 
         // Keywords match description and address, but does not match tag
         predicate = new TagContainsKeywordsPredicate(Arrays.asList("12345", "Main", "Street"));


### PR DESCRIPTION
Closes #5
- Add command to search for tasks based on tags (1 or more)
- Command format `tag-search [tag1] [tag2 ...]`
- Add tests related to the command