### PR TITLE
Add functionality to AddCommandParser and add test cases

### DIFF
--- a/src/main/java/seedu/taskify/logic/parser/AddCommandParser.java
+++ b/src/main/java/seedu/taskify/logic/parser/AddCommandParser.java
@@ -7,8 +7,11 @@ import static seedu.taskify.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.taskify.logic.parser.CliSyntax.PREFIX_TAG;
 
 import java.util.Set;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import java.util.stream.Stream;
 
+import seedu.taskify.commons.core.LogsCenter;
 import seedu.taskify.logic.commands.AddCommand;
 import seedu.taskify.logic.parser.exceptions.ParseException;
 import seedu.taskify.model.tag.Tag;
@@ -24,6 +27,8 @@ import seedu.taskify.model.task.Task;
  */
 public class AddCommandParser implements Parser<AddCommand> {
 
+    private static Logger logger = LogsCenter.getLogger(AddCommandParser.class);
+
     /**
      * Parses the given {@code String} of arguments in the context of the AddCommand
      * and returns an AddCommand object for execution.
@@ -36,6 +41,7 @@ public class AddCommandParser implements Parser<AddCommand> {
 
         if (!arePrefixesPresent(argMultimap, PREFIX_NAME, PREFIX_DESCRIPTION)
                     || !argMultimap.getPreamble().isEmpty()) {
+            logger.log(Level.WARNING, "Parse error");
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.MESSAGE_USAGE));
         }
 

--- a/src/main/java/seedu/taskify/logic/parser/AddCommandParser.java
+++ b/src/main/java/seedu/taskify/logic/parser/AddCommandParser.java
@@ -16,6 +16,7 @@ import seedu.taskify.model.task.Date;
 import seedu.taskify.model.task.Description;
 import seedu.taskify.model.task.Name;
 import seedu.taskify.model.task.Status;
+import seedu.taskify.model.task.StatusType;
 import seedu.taskify.model.task.Task;
 
 /**
@@ -33,15 +34,15 @@ public class AddCommandParser implements Parser<AddCommand> {
         ArgumentMultimap argMultimap =
                 ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_DESCRIPTION, PREFIX_DATE, PREFIX_TAG);
 
-        if (!arePrefixesPresent(argMultimap, PREFIX_NAME, PREFIX_DESCRIPTION, PREFIX_DATE)
+        if (!arePrefixesPresent(argMultimap, PREFIX_NAME, PREFIX_DESCRIPTION)
                     || !argMultimap.getPreamble().isEmpty()) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.MESSAGE_USAGE));
         }
 
         Name name = ParserUtil.parseName(argMultimap.getValue(PREFIX_NAME).get());
         Description description = ParserUtil.parseDescription(argMultimap.getValue(PREFIX_DESCRIPTION).get());
-        Status status = new Status();
-        Date date = ParserUtil.parseDate(argMultimap.getValue(PREFIX_DATE).get());
+        Status status = new Status(StatusType.NOT_DONE); // New task default StatusType is NOT_DONE.
+        Date date = generateDate(argMultimap);
         Set<Tag> tagList = ParserUtil.parseTags(argMultimap.getAllValues(PREFIX_TAG));
 
         Task task = new Task(name, description, status, date, tagList);
@@ -55,6 +56,21 @@ public class AddCommandParser implements Parser<AddCommand> {
      */
     private static boolean arePrefixesPresent(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
         return Stream.of(prefixes).allMatch(prefix -> argumentMultimap.getValue(prefix).isPresent());
+    }
+
+    /**
+     * Returns a {@code Date} depending on whether a date is specified in the arguments. If a date is
+     * specified in the arguments, return the corresponding Date. Else, returns a Date with today as the
+     * date with time of 23:59.
+     */
+    private static Date generateDate(ArgumentMultimap argumentMultimap) throws ParseException {
+        Date date;
+        if (arePrefixesPresent(argumentMultimap, PREFIX_DATE)) {
+            date = ParserUtil.parseDate(argumentMultimap.getValue(PREFIX_DATE).get());
+        } else {
+            date = Date.endOfToday();
+        }
+        return date;
     }
 
 }

--- a/src/main/java/seedu/taskify/logic/parser/ViewCommandParser.java
+++ b/src/main/java/seedu/taskify/logic/parser/ViewCommandParser.java
@@ -23,6 +23,7 @@ public class ViewCommandParser implements Parser<ViewCommand> {
      * @throws ParseException if the user input does not conform the expected format
      */
     public ViewCommand parse(String args) throws ParseException {
+        assert args != null : "String should not be null";
         String trimmedArgs = args.trim();
         if (trimmedArgs.isEmpty()) {
             throw new ParseException(

--- a/src/main/java/seedu/taskify/model/task/Date.java
+++ b/src/main/java/seedu/taskify/model/task/Date.java
@@ -5,6 +5,7 @@ import static seedu.taskify.commons.util.AppUtil.checkArgument;
 
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 
@@ -14,6 +15,7 @@ import java.time.format.DateTimeFormatter;
  */
 public class Date {
     public static final String MESSAGE_CONSTRAINTS = "Date should be of the format \"yyyy-mm-dd hh:mm\"";
+    private static final String END_OF_DAY_TIME = "23:59";
     public final String value;
     private final LocalDateTime localDateTime;
 
@@ -44,6 +46,16 @@ public class Date {
         } catch (ParseException ex) {
             return false;
         }
+    }
+
+    /**
+     * Returns a Date object with today's date and time of 23:59.
+     * @return Date object with today's date and time of 23:59.
+     */
+    public static Date endOfToday() {
+        String todayDateString = LocalDate.now().toString();
+        String todayDateTimeString = todayDateString + " " + END_OF_DAY_TIME;
+        return new Date(todayDateTimeString);
     }
 
     @Override

--- a/src/test/java/seedu/taskify/logic/parser/AddCommandParserTest.java
+++ b/src/test/java/seedu/taskify/logic/parser/AddCommandParserTest.java
@@ -15,7 +15,6 @@ import static seedu.taskify.logic.commands.CommandTestUtil.PREAMBLE_NON_EMPTY;
 import static seedu.taskify.logic.commands.CommandTestUtil.PREAMBLE_WHITESPACE;
 import static seedu.taskify.logic.commands.CommandTestUtil.TAG_DESC_FRIEND;
 import static seedu.taskify.logic.commands.CommandTestUtil.TAG_DESC_HUSBAND;
-import static seedu.taskify.logic.commands.CommandTestUtil.VALID_DATE_BOB;
 import static seedu.taskify.logic.commands.CommandTestUtil.VALID_DESCRIPTION_BOB;
 import static seedu.taskify.logic.commands.CommandTestUtil.VALID_NAME_BOB;
 import static seedu.taskify.logic.commands.CommandTestUtil.VALID_TAG_FRIEND;
@@ -24,6 +23,8 @@ import static seedu.taskify.logic.parser.CommandParserTestUtil.assertParseFailur
 import static seedu.taskify.logic.parser.CommandParserTestUtil.assertParseSuccess;
 import static seedu.taskify.testutil.TypicalTasks.AMY;
 import static seedu.taskify.testutil.TypicalTasks.BOB;
+
+import java.time.LocalDate;
 
 import org.junit.jupiter.api.Test;
 
@@ -81,12 +82,6 @@ public class AddCommandParserTest {
         assertParseFailure(parser, NAME_DESC_BOB + VALID_DESCRIPTION_BOB
                         + DATE_DESC_BOB, expectedMessage);
 
-
-        // missing date prefix
-        assertParseFailure(parser,
-                NAME_DESC_BOB + DESCRIPTION_DESC_BOB
-                        + VALID_DATE_BOB, expectedMessage);
-
         // all prefixes missing
         assertParseFailure(parser, VALID_NAME_BOB + VALID_DESCRIPTION_BOB
                         + VALID_NAME_BOB, expectedMessage);
@@ -119,5 +114,15 @@ public class AddCommandParserTest {
         assertParseFailure(parser, PREAMBLE_NON_EMPTY + NAME_DESC_BOB + DESCRIPTION_DESC_BOB
                          + DATE_DESC_BOB + TAG_DESC_HUSBAND + TAG_DESC_FRIEND,
                                 String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    // If no date prefix is specified, a Task with today's date with time set to 23:59 should be initialized.
+    public void parse_noDatePrefix_success() {
+        String args = " n/TestName desc/TestDesc";
+        String expectedDateString = LocalDate.now().toString() + " 23:59";
+        Task expectedTask = new TaskBuilder().withName("TestName").withDescription("TestDesc")
+                .withDate(expectedDateString).build();
+        assertParseSuccess(parser, args, new AddCommand(expectedTask));
     }
 }


### PR DESCRIPTION
Close #46 
AddCommand now does not require the date prefix. If date prefix (date/) is not specified, the added Task will have today's date, with time of 23:59.

eg:
"add n/Do laundry desc/With soap" should result in a Task with today's Date with time of 23:59.
