### PR TITLE
Add exceptions to handle leap year error. Add test cases.

### DIFF
--- a/src/main/java/seedu/taskify/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/taskify/logic/parser/ParserUtil.java
@@ -146,6 +146,12 @@ public class ParserUtil {
         requireNonNull(date);
         String trimmedDate = date.trim();
         if (!Date.isValidDate(trimmedDate)) {
+            if (Date.isInvalidLeapYearDate(trimmedDate)) {
+                throw new ParseException(Date.NOT_LEAP_YEAR_ERROR);
+            }
+            if (Date.isCorrectInputFormat(trimmedDate)) {
+                throw new ParseException(Date.CORRECT_FORMAT_BUT_INVALID_DATE);
+            }
             throw new ParseException(Date.MESSAGE_CONSTRAINTS);
         }
         return new Date(trimmedDate);

--- a/src/main/java/seedu/taskify/model/task/Date.java
+++ b/src/main/java/seedu/taskify/model/task/Date.java
@@ -8,13 +8,17 @@ import java.text.SimpleDateFormat;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
+import java.util.Calendar;
 
 /**
  * Represents a Task's date (and time) in the address book.
  * Guarantees: immutable; is valid as declared in {@link #isValidDate(String)}
  */
 public class Date {
+    public static final String CORRECT_FORMAT_BUT_INVALID_DATE =
+            "Maybe check if your specified date is an actual date and time?";
     public static final String MESSAGE_CONSTRAINTS = "Date should be of the format \"yyyy-mm-dd hh:mm\"";
+    public static final String NOT_LEAP_YEAR_ERROR = "Oops! The specified date is not a leap year!";
     private static final String END_OF_DAY_TIME = "23:59";
     public final String value;
     private final LocalDateTime localDateTime;
@@ -47,7 +51,7 @@ public class Date {
      * Returns if a given string is a valid date.
      */
     public static boolean isValidDate(String test) {
-        if (test == null || !test.matches("\\d{4}-\\d{2}-\\d{2} \\d{2}:\\d{2}")) {
+        if (!Date.isCorrectInputFormat(test)) {
             return false;
         }
         SimpleDateFormat df = new SimpleDateFormat("y-M-d H:m");
@@ -58,6 +62,38 @@ public class Date {
         } catch (ParseException ex) {
             return false;
         }
+    }
+
+    /**
+     * Returns if a given String is of correct format ("yyyy-MM-dd HH:mm").
+     */
+    public static boolean isCorrectInputFormat(String inputDate) {
+        return inputDate != null && inputDate.matches("\\d{4}-\\d{2}-\\d{2} \\d{2}:\\d{2}");
+    }
+
+    /**
+     * Returns if a given String date is of 29th February but not on a leap year.
+     */
+    public static boolean isInvalidLeapYearDate(String inputDate) {
+        if (Date.isCorrectInputFormat(inputDate)) {
+            String[] splitArr = inputDate.split("-");
+            int year = Integer.parseInt(splitArr[0]);
+            String month = splitArr[1];
+            String date = splitArr[2].split(" ")[0];
+            if (!isLeapYear(year) && month.equals("02") && date.equals("29")) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Returns if a given int is a leap year.
+     */
+    private static boolean isLeapYear(int year) {
+        Calendar cal = Calendar.getInstance();
+        cal.set(Calendar.YEAR, year);
+        return cal.getActualMaximum(Calendar.DAY_OF_YEAR) > 365;
     }
 
     /**

--- a/src/test/java/seedu/taskify/logic/parser/ParserUtilTest.java
+++ b/src/test/java/seedu/taskify/logic/parser/ParserUtilTest.java
@@ -24,20 +24,23 @@ import org.junit.jupiter.params.provider.ValueSource;
 
 import seedu.taskify.logic.parser.exceptions.ParseException;
 import seedu.taskify.model.tag.Tag;
+import seedu.taskify.model.task.Date;
 import seedu.taskify.model.task.Description;
 import seedu.taskify.model.task.Name;
 import seedu.taskify.model.task.Status;
 import seedu.taskify.model.task.StatusType;
 
 public class ParserUtilTest {
-    private static final String INVALID_NAME = "R@chel";
+    private static final String INVALID_NAME = "Buy @pples";
     private static final String INVALID_DESCRIPTION = "";
-    private static final String INVALID_TAG = "#friend";
+    private static final String INVALID_DATE = "20211-04-20 18:00";
+    private static final String INVALID_TAG = "#university";
 
-    private static final String VALID_NAME = "Rachel Walker";
-    private static final String VALID_DESCRIPTION = "123456";
-    private static final String VALID_TAG_1 = "friend";
-    private static final String VALID_TAG_2 = "neighbour";
+    private static final String VALID_NAME = "Buy apples";
+    private static final String VALID_DESCRIPTION = "Sweet apples";
+    private static final String VALID_DATE = "2021-04-20 18:00";
+    private static final String VALID_TAG_1 = "university";
+    private static final String VALID_TAG_2 = "CS2103T";
 
     private static final String WHITESPACE = " \t\r\n";
 
@@ -144,6 +147,23 @@ public class ParserUtilTest {
         String descriptionWithWhitespace = WHITESPACE + VALID_DESCRIPTION + WHITESPACE;
         Description expectedDescription = new Description(VALID_DESCRIPTION);
         assertEquals(expectedDescription, ParserUtil.parseDescription(descriptionWithWhitespace));
+    }
+
+    @Test
+    public void parseDate_null_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> ParserUtil.parseDate((String) null));
+    }
+
+    @Test
+    public void parseDate_invalidValue_throwsParseException() {
+        assertThrows(ParseException.class, () -> ParserUtil.parseDate(INVALID_DATE));
+    }
+
+    @Test
+    public void parseDate_validValueWithWhitespace_returnsCorrectDate() throws Exception {
+        String dateWithWhitespace = WHITESPACE + VALID_DATE + WHITESPACE;
+        Date expectedDate = new Date(VALID_DATE);
+        assertEquals(expectedDate, ParserUtil.parseDate(dateWithWhitespace));
     }
 
 

--- a/src/test/java/seedu/taskify/model/task/DateTest.java
+++ b/src/test/java/seedu/taskify/model/task/DateTest.java
@@ -49,4 +49,23 @@ class DateTest {
         assertEquals(new Date("1999-04-13 23:59"), new Date("1999-04-13 23:59"));
         assertEquals(new Date("2021-01-09 09:30"), new Date("2021-01-09 09:30"));
     }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"2021-04-13 10:30", "2020-04-13 10:30", "2020-04-32 10:30", "2020-04-13 25:30",
+            "2020-04-13 29:30", "2020-04-13 19:30", "2020-04-13 22:30", "2020-04-13 09:70", "2020-02-31 10:30"})
+    public void isCorrectInputFormat_correctFormat_success(String input) {
+        assertTrue(Date.isCorrectInputFormat(input));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"0001-02-29 10:30", "2021-02-29 10:30", "9999-02-29 23:59"})
+    public void isInvalidLeapYearDate_invalidLeapYearDate_success(String input) {
+        assertTrue(Date.isCorrectInputFormat(input));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"0000-02-29 10:30", "2020-02-29 10:30", "2024-02-29 23:59"})
+    public void isInvalidLeapYearDate_validLeapYearDate_fail(String input) {
+        assertTrue(Date.isCorrectInputFormat(input));
+    }
 }

--- a/src/test/java/seedu/taskify/model/task/DateTest.java
+++ b/src/test/java/seedu/taskify/model/task/DateTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.taskify.testutil.Assert.assertThrows;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 import org.junit.jupiter.api.Test;
@@ -60,12 +61,20 @@ class DateTest {
     @ParameterizedTest
     @ValueSource(strings = {"0001-02-29 10:30", "2021-02-29 10:30", "9999-02-29 23:59"})
     public void isInvalidLeapYearDate_invalidLeapYearDate_success(String input) {
-        assertTrue(Date.isCorrectInputFormat(input));
+        assertTrue(Date.isInvalidLeapYearDate(input));
     }
 
     @ParameterizedTest
     @ValueSource(strings = {"0000-02-29 10:30", "2020-02-29 10:30", "2024-02-29 23:59"})
     public void isInvalidLeapYearDate_validLeapYearDate_fail(String input) {
-        assertTrue(Date.isCorrectInputFormat(input));
+        assertFalse(Date.isInvalidLeapYearDate(input));
+    }
+
+    @Test
+    public void endOfToday_returnsEndOfTodayDate_success() {
+        String todayDateString = LocalDate.now().toString();
+        String todayDateTimeString = todayDateString + " " + "23:59";
+        Date expectedDate = new Date(todayDateTimeString);
+        assertEquals(Date.endOfToday(), expectedDate);
     }
 }


### PR DESCRIPTION
Fix #130 

If user calls `edit` or `add` with a `Date` of `02-29` and a `Non leap year` , returns an error message for this specific case.

Also added more error messages when users input a Date of correct format, but a Date that does not exist 
eg: `date/2021-04-50 18:00` or `date/2021-04-08 27:00`
